### PR TITLE
Added --failed option to display only failted test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ bash ./bashunit.bash
 Usage: <testscript> [options...]
 
 Options:
-  -v, --verbose  Print exptected and provided values
+  -v, --verbose  Print expected and provided values
   -s, --summary  Only print summary omitting individual test results
   -q, --quiet    Do not print anything to standard output
   -h, --help     Show usage screen

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Options:
   -v, --verbose  Print expected and provided values
   -s, --summary  Only print summary omitting individual test results
   -q, --quiet    Do not print anything to standard output
+  -l, --lineshow  Show failing or skipped line after line number
+  -f, --failed   Print only individual failed test results
   -h, --help     Show usage screen
 ```
 

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -186,6 +186,9 @@ runTests() {
 
     for tc in $testcases ; do $tc ; done
 
+    if [ $verbose -gt 1 ] ; then
+        printf "\033[K"
+    fi
     if [ $verbose -ge 1 ] ; then
         echo "Done. $bashunit_passed passed." \
              "$bashunit_failed failed." \

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -137,7 +137,7 @@ _passed() {
     local tc=${FUNCNAME[2]}
     local line=${BASH_LINENO[1]}
     if [ $verbose -ge 2 ] ; then
-        printf "$ts:\033[37;1m$tc\033[0m:$line:\033[32mPassed\033[0m$eol"
+        printf "\033[K$ts:\033[37;1m$tc\033[0m:$line:\033[32mPassed\033[0m$eol"
     fi
 }
 
@@ -154,7 +154,7 @@ _skipped() {
         else
             skipped_line=
         fi
-        printf "$ts:\033[37;1m$tc\033[0m:$line:\033[33mSkipped\033[0m${skipped_line}$eol"
+        printf "\033[K$ts:\033[37;1m$tc\033[0m:$line:\033[33mSkipped\033[0m${skipped_line}$eol"
     fi
 }
 
@@ -202,7 +202,7 @@ while [ $# -gt 0 ]; do
         "-s"|"--summary") verbose=1;;
         "-q"|"--quiet")   verbose=0;;
         "-l"|"--lineshow") lineshow=1;;
-        "-f"|"--failed")   eol="\033[K\r";;
+        "-f"|"--failed")   eol="\r";;
         "-h"|"--help")    usage; exit 0;;
         *) shift;;
     esac

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -7,6 +7,7 @@
 verbose=2
 caller=$0
 lineshow=0
+eol="\n"
 
 bashunit_passed=0
 bashunit_failed=0
@@ -136,7 +137,7 @@ _passed() {
     local tc=${FUNCNAME[2]}
     local line=${BASH_LINENO[1]}
     if [ $verbose -ge 2 ] ; then
-        echo -e "$ts:\033[37;1m$tc\033[0m:$line:\033[32mPassed\033[0m"
+        printf "$ts:\033[37;1m$tc\033[0m:$line:\033[32mPassed\033[0m$eol"
     fi
 }
 
@@ -153,7 +154,7 @@ _skipped() {
         else
             skipped_line=
         fi
-        echo -e "$ts:\033[37;1m$tc\033[0m:$line:\033[33mSkipped\033[0m${skipped_line}"
+        printf "$ts:\033[37;1m$tc\033[0m:$line:\033[33mSkipped\033[0m${skipped_line}$eol"
     fi
 }
 
@@ -169,6 +170,7 @@ usage() {
     echo "  -s, --summary   Only print summary omitting individual test results"
     echo "  -q, --quiet     Do not print anything to standard output"
     echo "  -l, --lineshow  Show failing or skipped line after line number"
+    echo "  -f, --failed    Print only individual failed test results"
     echo "  -h, --help      Show usage screen"
 }
 
@@ -200,6 +202,7 @@ while [ $# -gt 0 ]; do
         "-s"|"--summary") verbose=1;;
         "-q"|"--quiet")   verbose=0;;
         "-l"|"--lineshow") lineshow=1;;
+        "-f"|"--failed")   eol="\033[K\r";;
         "-h"|"--help")    usage; exit 0;;
         *) shift;;
     esac

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -174,9 +174,8 @@ usage() {
 
 runTests() {
     local test_pattern="test[a-zA-Z0-9_]\+"
-    local testcases=$(declare -f | \
-        sed -ne '/'"$test_pattern"' () *$/ { s/() *$// ; p }' | \
-        grep -o $test_pattern)
+    local testcases=$(declare -F | \
+        sed -ne '/'"$test_pattern"'$/ { s/declare -f // ; p }')
 
     if [ ! "${testcases[*]}" ] ; then
         usage

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -122,7 +122,7 @@ _failed() {
         else
             failed_line=
         fi
-        echo -e "$ts:\033[37;1m$tc\033[0m:$line:\033[31mFailed\033[0m${failed_line}"
+        echo -e "\033K[$ts:\033[37;1m$tc\033[0m:$line:\033[31mFailed\033[0m${failed_line}"
     fi
     if [ $verbose -eq 3 ] ; then
         echo -e "\033[31mExpected\033[0m: $(sed '2,$ s/^/          /g' <<<$2)"

--- a/bashunit.bash
+++ b/bashunit.bash
@@ -165,7 +165,7 @@ usage() {
     echo "Usage: <testscript> [options...]"
     echo
     echo "Options:"
-    echo "  -v, --verbose   Print exptected and provided values"
+    echo "  -v, --verbose   Print expected and provided values"
     echo "  -s, --summary   Only print summary omitting individual test results"
     echo "  -q, --quiet     Do not print anything to standard output"
     echo "  -l, --lineshow  Show failing or skipped line after line number"


### PR DESCRIPTION
When developping what is really interesting are cases which introduce regressions, using -f we only display such failed results (-v and -l meaning are preserved).